### PR TITLE
Restore last selected dish display

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -71,7 +71,7 @@ function isDishCookable(dishFoods) {
 // カテゴリ選択時に料理リストを更新する関数
 function updateFoodOptions(selectedCategory) {
   // 現在選択されている料理を保存（作れない料理かどうかをチェックするため）
-  const currentSelectedDish = foodSelect.value;
+  let currentSelectedDish = foodSelect.value;
   
   foodSelect.innerHTML = '<option value="">-- 料理を選択 --</option>';
 
@@ -92,6 +92,9 @@ function updateFoodOptions(selectedCategory) {
       currentDishIsUncookable = !isDishCookable(currentDishFoods);
       // 現在選択されている料理が表示されるかどうか
       currentDishWillBeVisible = !hideUncookable || !currentDishIsUncookable;
+    } else if (currentSelectedDish) {
+      // 別カテゴリの料理が選択されている場合はリセット
+      currentSelectedDish = '';
     }
     
     // 選択されたカテゴリに属する料理をfoodSelectに追加


### PR DESCRIPTION
献立表でカテゴリ変更時に最後に選択していた料理を表示する機能を復元します。

`updateFoodOptions`関数がカテゴリ切り替え前の選択値を保持し続け、新しいカテゴリに存在しない料理でも`currentSelectedDish`がリセットされなかったため、localStorageからの復元処理が実行されていませんでした。`currentSelectedDish`を`let`に変更し、新しいカテゴリに同名の料理が存在しない場合は選択値をリセットするように修正しました。

---
<a href="https://cursor.com/background-agent?bcId=bc-cc793a54-727d-448f-81de-ff5b802284d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cc793a54-727d-448f-81de-ff5b802284d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the selected dish is reset when switching to a category that lacks the previously selected dish, allowing saved selections to be restored.
> 
> - **UI logic (`js/common.js`)**:
>   - `updateFoodOptions`: change `currentSelectedDish` from `const` to `let` and reset it (`''`) when the previously selected dish doesn't exist in the new category.
>   - Preserves/restore selection only if the dish exists and is visible; otherwise reads from `localStorage`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4377cc366dcd65128d87ac3e5a2ea26cb899e87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->